### PR TITLE
Fix: Collapsing Team Cards in Prod

### DIFF
--- a/src/components/PivotDataTeamCard/PivotDataTeamCard.js
+++ b/src/components/PivotDataTeamCard/PivotDataTeamCard.js
@@ -9,16 +9,12 @@ function PivotDataTeamCard(props) {
 						<div className="card-back">
 							<img
 								className="card-img-top"
-								style={{ width: 235, height: 235 }}
 								src={props.dataTeamMember.gif}
 								stylealt="Gif"
 								alt=""
 							/>
 						</div>
-						<div
-							className="card card-front"
-							style={{ width: 235, height: 235 }}
-						>
+						<div className="card card-front">
 							<img
 								className="card-img-top team-photo"
 								src={props.dataTeamMember.image}

--- a/src/components/PivotExecTeamCard/PivotExecTeamCard.js
+++ b/src/components/PivotExecTeamCard/PivotExecTeamCard.js
@@ -9,16 +9,12 @@ function PivotExecTeamCard(props) {
 						<div className="card-back">
 							<img
 								className="card-img-top"
-								style={{ width: 235, height: 235 }}
 								src={props.execTeamMember.gif}
 								stylealt="Gif"
 								alt=""
 							/>
 						</div>
-						<div
-							className="card card-front"
-							style={{ width: 235, height: 235 }}
-						>
+						<div className="card card-front">
 							<img
 								className="card-img-top team-photo"
 								src={props.execTeamMember.image}

--- a/src/components/PivotOpsTeamCard/PivotOpsTeamCard.js
+++ b/src/components/PivotOpsTeamCard/PivotOpsTeamCard.js
@@ -9,16 +9,12 @@ function PivotOpsTeamCard(props) {
 						<div className="card-back">
 							<img
 								className="card-img-top"
-								style={{ width: 235, height: 235 }}
 								src={props.opsTeamMember.gif}
 								stylealt="Gif"
 								alt=""
 							/>
 						</div>
-						<div
-							className="card card-front"
-							style={{ width: 235, height: 235 }}
-						>
+						<div className="card card-front">
 							<img
 								className="card-img-top team-photo"
 								src={props.opsTeamMember.image}

--- a/src/components/PivotWebTeamCard/PivotWebTeamCard.js
+++ b/src/components/PivotWebTeamCard/PivotWebTeamCard.js
@@ -9,16 +9,12 @@ function PivotWebTeamCard(props) {
 						<div className="card-back">
 							<img
 								className="card-img-top"
-								style={{ width: 235, height: 235 }}
 								src={props.webTeamMember.gif}
 								stylealt="Gif"
 								alt=""
 							/>
 						</div>
-						<div
-							className="card card-front"
-							style={{ width: 235, height: 235 }}
-						>
+						<div className="card card-front">
 							<img
 								className="card-img-top team-photo"
 								src={props.webTeamMember.image}

--- a/src/pages/PivotTeamPage/PivotTeamPage.scss
+++ b/src/pages/PivotTeamPage/PivotTeamPage.scss
@@ -1,106 +1,111 @@
 .team-category {
-	display: flex;
-	justify-content: space-around;
-	flex-wrap: wrap;
-	padding: 0 20px;
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  padding: 0 20px;
 }
 
 .header {
-	color: navy;
+  color: navy;
 }
 
 hr {
-	border: 1px solid navy !important;
+  border: 1px solid navy !important;
 }
 
 .title {
-	text-align: center;
-	padding: 0 20px;
+  text-align: center;
+  padding: 0 20px;
 }
 
 .header-sub {
-	color: orange;
+  color: orange;
 }
 
 .team-photo {
-	-webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
-	filter: grayscale(100%);
-	width: 235px;
-	height: 233px;
+  -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+  filter: grayscale(100%);
+  width: 235px;
+  height: 233px;
 }
 
 .pivot-card {
-	color: navy;
+  color: navy;
 }
 
 .pivot-team-cards {
-	color: navy;
-	margin: 50px 0;
+  color: navy;
+  margin: 50px 0;
 }
 
 .team-name {
-	font-size: 20px;
-	font-weight: 400px;
+  font-size: 20px;
+  font-weight: 400px;
 }
 
 .team-position {
-	font-size: 14px;
+  font-size: 14px;
 }
 
 .pivot-team-cards {
-	margin-left: 20px !important;
-	margin-right: 20px !important;
+  margin-left: 20px !important;
+  margin-right: 20px !important;
 }
 
 .flip-card-inner {
-	position: relative;
-	width: 100%;
-	height: 100%;
-	text-align: center;
-	transition: transform 0.8s;
-	transform-style: preserve-3d;
+  position: relative;
+  width: 235px;
+  height: 235px;
+  text-align: center;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
 }
 
 .pivot-card:hover .flip-card-inner {
-	transform: rotateY(180deg);
+  transform: rotateY(180deg);
 }
 
 .card-front,
 .card-back {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	-webkit-backface-visibility: hidden; /* Safari */
-	backface-visibility: hidden;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  & img {
+    width: 100%;
+    height: 100%;
+    -webkit-backface-visibility: hidden; /* Safari */
+    backface-visibility: hidden;
+  }
 }
 
 .card-front {
-	background-color: #bbb;
-	color: black;
+  background-color: #bbb;
+  color: black;
 }
 
 .card-back {
-	color: navy;
-	transform: rotateY(180deg);
+  color: navy;
+  transform: rotateY(180deg);
 }
 
 .meet-team-text {
-	font-size: 40px;
+  font-size: 40px;
 }
 
 .team-collage {
-	max-width: 100% !important;
-	margin: 0;
-	height: auto;
-	width: auto;
+  max-width: 100% !important;
+  margin: 0;
+  height: auto;
+  width: auto;
 }
 
 .hero-team {
-	background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
-		url('https://images.unsplash.com/photo-1546793851-527c1ab2a32a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1267&q=80');
-	height: 500px;
-	background-position: center;
-	background-repeat: no-repeat;
-	background-size: cover;
-	position: relative;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url("https://images.unsplash.com/photo-1546793851-527c1ab2a32a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1267&q=80");
+  height: 500px;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  position: relative;
 }

--- a/src/pages/PivotTeamPage/PivotTeamPage.scss
+++ b/src/pages/PivotTeamPage/PivotTeamPage.scss
@@ -1,111 +1,110 @@
 .team-category {
-  display: flex;
-  justify-content: space-around;
-  flex-wrap: wrap;
-  padding: 0 20px;
+	display: flex;
+	justify-content: space-around;
+	flex-wrap: wrap;
+	padding: 0 20px;
 }
 
 .header {
-  color: navy;
+	color: navy;
 }
 
 hr {
-  border: 1px solid navy !important;
+	border: 1px solid navy !important;
 }
 
 .title {
-  text-align: center;
-  padding: 0 20px;
+	text-align: center;
+	padding: 0 20px;
 }
 
 .header-sub {
-  color: orange;
+	color: orange;
 }
 
 .team-photo {
-  -webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
-  filter: grayscale(100%);
-  width: 235px;
-  height: 233px;
+	-webkit-filter: grayscale(100%); /* Safari 6.0 - 9.0 */
+	filter: grayscale(100%);
+	width: 235px;
+	height: 233px;
 }
 
 .pivot-card {
-  color: navy;
+	color: navy;
 }
 
 .pivot-team-cards {
-  color: navy;
-  margin: 50px 0;
+	color: navy;
+	margin: 50px 0;
 }
 
 .team-name {
-  font-size: 20px;
-  font-weight: 400px;
+	font-size: 20px;
+	font-weight: 400px;
 }
 
 .team-position {
-  font-size: 14px;
+	font-size: 14px;
 }
 
 .pivot-team-cards {
-  margin-left: 20px !important;
-  margin-right: 20px !important;
+	margin-left: 20px !important;
+	margin-right: 20px !important;
 }
 
 .flip-card-inner {
-  position: relative;
-  width: 235px;
-  height: 235px;
-  text-align: center;
-  transition: transform 0.8s;
-  transform-style: preserve-3d;
+	position: relative;
+	width: 235px;
+  	height: 235px;
+	text-align: center;
+	transition: transform 0.8s;
+	transform-style: preserve-3d;
 }
 
 .pivot-card:hover .flip-card-inner {
-  transform: rotateY(180deg);
+	transform: rotateY(180deg);
 }
 
 .card-front,
 .card-back {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  & img {
-    width: 100%;
-    height: 100%;
-    -webkit-backface-visibility: hidden; /* Safari */
-    backface-visibility: hidden;
-  }
+	position: absolute;
+	width: 100%;
+	overflow: hidden;
+	& img {
+		width: 100%;
+		height: 100%;
+		-webkit-backface-visibility: hidden; /* Safari */
+		backface-visibility: hidden;
+	}
 }
 
 .card-front {
-  background-color: #bbb;
-  color: black;
+	background-color: #bbb;
+	color: black;
 }
 
 .card-back {
-  color: navy;
-  transform: rotateY(180deg);
+	color: navy;
+	transform: rotateY(180deg);
 }
 
 .meet-team-text {
-  font-size: 40px;
+	font-size: 40px;
 }
 
 .team-collage {
-  max-width: 100% !important;
-  margin: 0;
-  height: auto;
-  width: auto;
+	max-width: 100% !important;
+	margin: 0;
+	height: auto;
+	width: auto;
 }
 
 .hero-team {
-  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
-    url("https://images.unsplash.com/photo-1546793851-527c1ab2a32a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1267&q=80");
-  height: 500px;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  position: relative;
+	background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+		url('https://images.unsplash.com/photo-1546793851-527c1ab2a32a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1267&q=80');
+	height: 500px;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: cover;
+	position: relative;
 }


### PR DESCRIPTION
Fixes collapsing team member cards in production.

### CSS Specificity Issue

The root cause of the problem was css specificity on `div.card.card-front`. When ran locally, the `.card` class takes precedent applying `position: relative` to the element. Once the project runs in prod, however, `.card-front` wins. `.card-front` applies `position: absolute` causing the element to be removed from the document flow and its height/width to no longer be reflected in the parent. The result is the parent `.flip-card-inner` element's height and width collapsing down to the remaining text nodes.

### Running Locally
<img width="298" alt="Screen Shot 2020-11-17 at 8 47 48 AM" src="https://user-images.githubusercontent.com/25045075/99415743-bf661380-28bd-11eb-86b0-59f0d09ee753.png">

### Running on Firebase
<img width="296" alt="Screen Shot 2020-11-17 at 8 47 33 AM" src="https://user-images.githubusercontent.com/25045075/99415746-bffeaa00-28bd-11eb-97b3-484d555e90cb.png">
